### PR TITLE
fix maxlength html attribute for mobile, and product name overlap:

### DIFF
--- a/shopping-list/index.css
+++ b/shopping-list/index.css
@@ -59,6 +59,7 @@ ul#products-list {
     position: relative;
     max-height: 250px;
     visibility: visible;
+    overflow: auto;
 }
 
 li {

--- a/shopping-list/index.html
+++ b/shopping-list/index.html
@@ -28,15 +28,17 @@
             </ul>
         </div>
 
+        <!--  this function to apply maxlength for inputs, applies only for mobile phones -> if(this.value.length >= this.getAttribute('maxlength')) return false;      -->
+
         <form id="add-item" class="form-container">
             <div>
                 <label for="addInput">Insert Name of Product: </label>
-                <input type="text" minlength="3" maxlength="15" placeholder="product name" id="addInput">
+                <input type="text" minlength="3" maxlength="15" placeholder="product name" id="addInput" onkeypress="if(this.value.length >= this.getAttribute('maxlength')) return false;">
             </div>
 
             <div>
                 <label for="addPrice">Insert Price of Product: </label>
-                <input type="number" step="any" placeholder="product price" id="addPrice">
+                <input type="number" step="any" maxlength="10" placeholder="product price" id="addPrice" onkeypress="if(this.value.length >= this.getAttribute('maxlength')) return false;">
             </div>
 
             <button id="add-product-btn">Add product</button>


### PR DESCRIPTION
fix maxlength html attribute for mobile, and product name overlap:
  - added a function for onkeypress for both inputs, to set maxlength using javascript, otherwise maxlength was ignored on mobile phones
  - added overflow for list to prevent product name overlapping over price floating element